### PR TITLE
Support for new types and basic conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /pom.xml*
 /.env
 .DS_Store
+.nreplport

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /logs/
 /docs/
 /doc/
+/local-dynamo/
 /*.jar
 /*.class
 /.lein*
@@ -12,3 +13,4 @@
 /.env
 .DS_Store
 .nreplport
+.nrepl-port

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 > This project uses [Break Versioning](https://github.com/ptaoussanis/encore/blob/master/BREAK-VERSIONING.md) as of **Aug 16, 2014**.
 
+## SNAPSHOT / unreleased
+
+ * **BREAKING**: `update-item` no longer treats `false` as a special value to denote attribute exists in `:expected`. Attribute existances is now tested for with the `:exists` and `:not-exists` keywords.
+ * **NEW**: `update-item` now accepts the comparison operators in `:expected`.
+ * **NEW**: Boolean, Null, Map and List types now supported.
+
 ## v1.5.0 / 2014 July 26
 
  * **NEW**: allow reading of binary values written with other (non-serializing) clients.

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
   [[org.clojure/clojure        "1.5.1"]
    [com.taoensso/encore        "1.15.1"]
    [com.taoensso/nippy         "2.7.0"]
-   [com.amazonaws/aws-java-sdk "1.9.6" :exclusions [joda-time]]
+   [com.amazonaws/aws-java-sdk "1.9.10" :exclusions [joda-time]]
    [joda-time                  "2.5"] ; For exclusion, see Github #27
    ]
 

--- a/run-tests
+++ b/run-tests
@@ -9,6 +9,18 @@ elif [ "$1" != "local" ] && [ ! -f "$1" ]; then
 else
 
   if [ "$1" = "local" ]; then
+
+    if [ ! -f ./local-dynamo/DynamoDBLocal.jar ]; then
+      echo "Downloading local dynamo"
+      mkdir local-dynamo
+      cd local-dynamo
+      wget "http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz"
+      tar zxf dynamodb_local_latest.tar.gz
+      rm dynamodb_local_latest.tar.gz
+      cd -
+    fi
+
+
     echo "Starting local Dynamodb"
     java -Djava.library.path=./local-dynamo/DynamoDBLocal_lib -jar ./local-dynamo/DynamoDBLocal.jar -port 6798 -inMemory &
     trap "pkill -f DynamoDBLocal" EXIT

--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -13,14 +13,8 @@
             [taoensso.encore        :as encore :refer (doto-cond)]
             [taoensso.nippy         :as nippy]
             [taoensso.nippy.tools   :as nippy-tools]
-            [taoensso.faraday.utils :as utils :refer (coll?* seperate-update-types)])
+            [taoensso.faraday.utils :as utils :refer (coll?*)])
   (:import  [clojure.lang BigInt]
-            [com.amazonaws.services.dynamodbv2.document.utils
-             ValueMap]
-            [com.amazonaws.services.dynamodbv2.document.spec
-             UpdateItemSpec]
-            [com.amazonaws.services.dynamodbv2.document
-             DynamoDB]
             [com.amazonaws.services.dynamodbv2.model
              AttributeDefinition
              AttributeValue

--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -667,7 +667,7 @@
         (if (vector? %)
           (doto (ExpectedAttributeValue.)
             (.withComparisonOperator (enum-op (first %)))
-            (.setValue (clj-val->db-val (second %))))
+            (.setAttributeValueList (mapv clj-val->db-val (rest %))))
           (ExpectedAttributeValue. (clj-val->db-val %))))
      expected-map)))
 
@@ -723,7 +723,9 @@
     prim-kvs   - {<hash-key> <val>} or {<hash-key> <val> <range-key> <val>}.
     update-map - {<attr> [<#{:put :add :delete}> <optional value>]}.
     :return    - e/o #{:none :all-old :updated-old :all-new :updated-new}.
-    :expected  - {<attr> <#{<expected-value> false}> ...}."
+    :expected  - {<attr> <#{:exists :not-exists [comparison-operators <value>] <value>}> ...}.
+
+  Where comparison-operators e/o #{:eq :le :lt :ge :gt :begins-with :between}."
   [client-opts table prim-kvs update-map & [{:keys [return expected return-cc?]
                                              :as   opts}]]
   (as-map

--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -688,7 +688,10 @@
   [update-map]
   (when (seq update-map)
     (utils/name-map
-     (fn [[action val]] (AttributeValueUpdate. (when val (clj-val->db-val val))
+     (fn [[action val]] (AttributeValueUpdate. (when
+                                                  (or (not= action :delete)
+                                                      (set? val))
+                                                (clj-val->db-val val))
                                               (utils/enum action)))
      update-map)))
 

--- a/test/taoensso/faraday/tests/main.clj
+++ b/test/taoensso/faraday/tests/main.clj
@@ -203,7 +203,8 @@
 
 ;;;; expectation tests
 (let [t {:id 16
-         :val 1}]
+         :val 1
+         :str "abc"}]
 
   (expect
    (update-in t [:val] inc)
@@ -227,7 +228,19 @@
    (update-in t [:val] inc)
    (update-t
     {:val [:add 1]}
-    {:expected {:val [:= 1]}}))
+    {:expected {:val [:eq 1]}}))
+
+  (expect
+   (update-in t [:val] inc)
+   (update-t
+    {:val [:add 1]}
+    {:expected {:str [:begins-with "a"]}}))
+
+  (expect
+   (update-in t [:val] inc)
+   (update-t
+    {:val [:add 1]}
+    {:expected {:val [:between 0 2]}}))
 
   (expect
    ConditionalCheckFailedException

--- a/test/taoensso/faraday/tests/main.clj
+++ b/test/taoensso/faraday/tests/main.clj
@@ -125,6 +125,33 @@
    (far/scan *client-opts* ttable {:attr-conds {:test [:eq "batch"]}
                                    :return [:test]})))
 
+;;;; type check
+(let [t {:id 14
+         :boolT true
+         :boolF false
+         :string "string"
+         :num 1
+         :null nil
+         :numset #{4 12 6 13}
+         :strset #{"a" "b" "c"}
+         :map {:k1 "v1" :k2 "v2" :k3 "v3"}
+         :vec ["a" 1 false nil]}
+      take-care-of-map-keys {:id 15
+                             :map {:key "val" "key" 5}}]
+
+  (after-setup!
+   #(do
+      (far/put-item *client-opts* ttable t)
+      (far/put-item *client-opts* ttable take-care-of-map-keys)))
+
+  (expect
+   t
+   (far/get-item *client-opts* ttable {:id (:id t)}))
+  (expect
+   {:id 15
+    :map {:key 5}}
+   (far/get-item *client-opts* ttable {:id (:id take-care-of-map-keys)})))
+
 ;;;; range queries
 (let [j0 {:title "One" :number 0}
       j1 {:title "One" :number 1}

--- a/test/taoensso/faraday/tests/main.clj
+++ b/test/taoensso/faraday/tests/main.clj
@@ -196,11 +196,9 @@
     {:boolT [:put nil]}))
 
   (expect
-   (assoc-in t [:map :new] "x")
+   (assoc-in t [:map-new :new] "x")
    (update-t
-    {:map [:add {:new "x"}]}))
-
-  )
+    {:map-new [:put {:new "x"}]})))
 
 
 

--- a/test/taoensso/faraday/tests/requests.clj
+++ b/test/taoensso/faraday/tests/requests.clj
@@ -152,7 +152,9 @@
           (.getItem req))
   (expect {"e1" (doto (ExpectedAttributeValue.)
                   (.setValue (AttributeValue. "expected value")))
-           "e2" (ExpectedAttributeValue. false)}
+           "e2" (doto (ExpectedAttributeValue.)
+                  (.setValue (doto (AttributeValue.)
+                               (.setBOOL false))))}
           (.getExpected req)))
 
 (let [req
@@ -164,7 +166,7 @@
                            :a [:delete]}
                           {:expected {:e1 "expected!"}
                            :return :updated-old})]
-  
+
   (expect "update-item" (.getTableName req))
   (expect {"x" (doto (AttributeValue.)
                  (.setN "1"))}
@@ -189,7 +191,7 @@
                           {:k1 "val" :r1 -3}
                           {:return :all-new
                            :expected {:e1 1}})]
-  
+
   (expect "delete-item" (.getTableName req))
   (expect {"k1" (AttributeValue. "val")
            "r1" (doto (AttributeValue.)


### PR DESCRIPTION
I've added tests for the new types and added support for the most basic of condition tests. 

The main thing of note is a breaking change to use of 'false' to denote a nonexistent column. Now that Boolean types have been added this just doesn't work, so the keywords :exists and :not-exist have been added to the update function. The simple conditions have been added as a vector of [op val] to update as well.