### PR TITLE
JC: Fix cc-units for batch responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## SNAPSHOT / unreleased
+ * **Fix** [#49]: Batch operations weren't returning consumed capacity
+
 ## v1.5.0 / 2014 July 26
 
  * **NEW**: allow reading of binary values written with other (non-serializing) clients.

--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -238,6 +238,13 @@
 
 (defn- cc-units [^ConsumedCapacity cc] (some-> cc (.getCapacityUnits)))
 
+(def ^:private batch-cc-units
+  (partial
+    reduce
+    (fn [m cc]
+      (assoc m (keyword (.getTableName cc)) (cc-units cc)))
+    {}))
+
 (defprotocol AsMap (as-map [x]))
 
 (defmacro ^:private am-item-result [result get-form]
@@ -283,12 +290,12 @@
   (as-map [r]
     {:items       (utils/keyword-map as-map (.getResponses r))
      :unprocessed (.getUnprocessedKeys r)
-     :cc-units    (cc-units (.getConsumedCapacity r))})
+     :cc-units    (batch-cc-units (.getConsumedCapacity r))})
 
   BatchWriteItemResult
   (as-map [r]
     {:unprocessed (.getUnprocessedItems r)
-     :cc-units    (cc-units (.getConsumedCapacity r))})
+     :cc-units    (batch-cc-units (.getConsumedCapacity r))})
 
   TableDescription
   (as-map [d]


### PR DESCRIPTION
This fixes an error I was seeing in trying to return the consumed capacity from batch operations:

```clojure
=> (faraday/batch-get-item options {:my_table {:prim-kvs {:my_key ["foo" "bar"]}}} {:return-cc? true}))

CompilerException java.lang.ClassCastException: com.amazonaws.internal.ListWithAutoConstructFlag cannot be cast to com.amazonaws.services.dynamodbv2.model.ConsumedCapacity, compiling:(form-init4303440963934561960.clj:1:12)
```

The patch adds a `batch-cc-units` method which is called from the `as-map` implementations for `BatchGetItemResult` and `BatchWriteItemResult`.