### PR TITLE
Change the type hint of `db-client` to AmazonDynamoDB

### DIFF
--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -76,6 +76,7 @@
             com.amazonaws.auth.BasicAWSCredentials
             com.amazonaws.auth.DefaultAWSCredentialsProviderChain
             com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
+            com.amazonaws.services.dynamodbv2.AmazonDynamoDB
             java.nio.ByteBuffer))
 
 ;; TODO Add support for splitting data > 64KB over > 1 keys? This may be tough
@@ -118,7 +119,7 @@
                          (AmazonDynamoDBClient. aws-creds client-config))]
            endpoint (.setEndpoint g)))))))
 
-(defn- db-client ^AmazonDynamoDBClient [client-opts] (db-client* client-opts))
+(defn- db-client ^AmazonDynamoDB [client-opts] (db-client* client-opts))
 
 ;;;; Exceptions
 

--- a/src/taoensso/faraday/utils.clj
+++ b/src/taoensso/faraday/utils.clj
@@ -1,7 +1,6 @@
 (ns taoensso.faraday.utils
   {:author "Peter Taoussanis"}
-  (:require [clojure.string  :as str]
-            [taoensso.encore :as encore]))
+  (:require [clojure.string  :as str]))
 
 (defn map-kvs [kf vf m]
   (let [m (if (instance? java.util.HashMap m) (into {} m) m)]


### PR DESCRIPTION
The current hint is too specific and hinders mocking, so I changed it to the interface `AmazonDynamoDB` from `AmazonDynamoDBClient`. Also, in another commit I removed an unused require.