### PR TITLE
Add sanitization multimethod to strip empty values

### DIFF
--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -1063,6 +1063,29 @@
       (let [items item-or-items]
         (into {} (mapv (partial item-by-attrs attr-or-attrs) items))))))
 
+(defn- empty-seq->nil [s]
+  (when (seq s) s))
+
+(defmulti sanitize class)
+
+(defmethod sanitize clojure.lang.Sequential [x]
+  (empty-seq->nil
+   (into [] (filter (comp not nil?) (map sanitize x)))))
+
+(defmethod sanitize clojure.lang.IPersistentMap [x]
+  (into {} (filter (comp (partial = 2) count) (map sanitize x))))
+
+(defmethod sanitize java.lang.String [x]
+  (when-not (clojure.string/blank? x)
+    x))
+
+(defmethod sanitize clojure.lang.IPersistentSet [x]
+  (empty-seq->nil
+   (into #{} (filter (comp not nil?) (map sanitize x)))))
+
+(defmethod sanitize :default [x]
+  x)
+
 (comment
   (items-by-attrs :a      {:a :A :b :B :c :C})
   (items-by-attrs [:a]    {:a :A :b :B :c :C})

--- a/test/taoensso/faraday/tests/main.clj
+++ b/test/taoensso/faraday/tests/main.clj
@@ -364,3 +364,6 @@
            deref
            :throughput
            (select-keys #{:read :write}))))))
+
+(expect {:b [{:a "b"} {}]}
+        (far/sanitize {:b [{:a "b" :c [[]] :d #{}}, {}] :a nil :empt-str "" :e #{""}}))


### PR DESCRIPTION
This is just a helper function that can be used to recursively strip empty values before giving to dynamodb. It converts empty sets and strings.

See invalid values at http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeValueUpdate.html