### PR TITLE
Support Keep Alive in ClientConfiguration

### DIFF
--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -116,7 +116,8 @@
                conn-timeout    (.setConnectionTimeout g)
                max-conns       (.setMaxConnections    g)
                max-error-retry (.setMaxErrorRetry     g)
-               socket-timeout  (.setSocketTimeout     g))]
+               socket-timeout  (.setSocketTimeout     g)
+               keep-alive      (.setUseTcpKeepAlive   g))]
          (doto-cond [g (if provider
                          (AmazonDynamoDBClient. provider  client-config)
                          (AmazonDynamoDBClient. aws-creds client-config))]


### PR DESCRIPTION
Setting Keep Alive will use persistent HTTP connections. Use of these
persistent HTTP connections is strongly recommended for achieving the
lowest latency possible to DynamoDB.