### PR TITLE
Fix removal of whitespace-only strings

### DIFF
--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -1097,7 +1097,7 @@
             (fn rf [acc in] (let [v* (f1 in)] (if (nil? v*) acc (conj acc v*))))
             (if (sequential? x) [] (empty x)) x))
 
-        (string?       x) (when-not (str/blank? x)             x)
+        (string?       x) (when-not (empty? x)                 x)
         (encore/bytes? x) (when-not (zero? (alength ^bytes x)) x)
         :else x))))
 

--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -1097,7 +1097,7 @@
             (fn rf [acc in] (let [v* (f1 in)] (if (nil? v*) acc (conj acc v*))))
             (if (sequential? x) [] (empty x)) x))
 
-        (string?       x) (when-not (empty? x)                 x)
+        (string?       x) (when-not (.isEmpty ^String x)       x)
         (encore/bytes? x) (when-not (zero? (alength ^bytes x)) x)
         :else x))))
 

--- a/test/taoensso/faraday/tests/main.clj
+++ b/test/taoensso/faraday/tests/main.clj
@@ -365,6 +365,6 @@
            :throughput
            (select-keys #{:read :write}))))))
 
-(expect {:b [{:a "b"}], :f false}
+(expect {:b [{:a "b"}], :f false, :g "    "}
   (far/remove-empty-attr-vals
-    {:b [{:a "b" :c [[]] :d #{}}, {}] :a nil :empt-str "" :e #{""} :f false}))
+    {:b [{:a "b" :c [[]] :d #{}}, {}] :a nil :empt-str "" :e #{""} :f false :g "    "}))


### PR DESCRIPTION
Just a fix to `remove-empty-attr-vals`: blank strings (or whitespace only strings) are valid; only strings with a length of zero are invalid.

Switched `blank?` to `empty?` and added a test case.