### PR TITLE
Add expressions support to put-item and update-item.

### DIFF
--- a/test/taoensso/faraday/tests/main.clj
+++ b/test/taoensso/faraday/tests/main.clj
@@ -97,8 +97,46 @@
   (expect
    #= (far/ex :conditional-check-failed)
    (far/update-item *client-opts* ttable
-       {:id 10} {:name [:put "baz"]}
-       {:expected {:name "garbage"}})))
+                    {:id 10} {:name [:put "baz"]}
+                    {:expected {:name "garbage"}})))
+
+
+
+;; Expressions support
+(let [i {:id 10 :name "update me"}]
+  (after-setup!
+   #(far/delete-item *client-opts* ttable {:id 10}))
+
+  (expect ; Update expression support in update-item
+   {:id 10 :name "foo"}
+   (do
+     (far/update-item *client-opts* ttable
+                      {:id 10}
+                      {}
+                      {:update-expression      "SET #name = :name"
+                       :expression-attr-names  {"#name" "name"}
+                       :expression-attr-values {":name" "foo"}
+                       :return :all-new})))
+
+  (expect ; Condition expression support in update-item
+   #= (far/ex :conditional-check-failed)
+   (do
+     (far/update-item *client-opts* ttable
+                      {:id 10}
+                      {}
+                      {:update-expression      "SET #name = :name"
+                       :expression-attr-names  {"#name" "name"}
+                       :expression-attr-values {":name" "foo"}
+                       :condition-expression   "#name <> :name"
+                       :return :all-new})))
+
+  (expect ; Condition expression support in put-item
+   #= (far/ex :conditional-check-failed)
+   (do
+     (far/put-item *client-opts* ttable i
+                   {:condition-expression "attribute_not_exists(id) AND #name <> :name"
+                    :expression-attr-names  {"#name" "name"}
+                    :expression-attr-values {":name" "foo"}}))))
 
 (let [items [{:id 11 :name "eleven" :test "batch"}
              {:id 12 :name "twelve" :test "batch"}


### PR DESCRIPTION
This adds support to Dynamo's expressions which can be used for conditions and updates. It's the preferred way documented in DynamoDB's API.

I've also taken the liberty to deprecate and print warnings for the legacy ways so it doesn't break any existing code but still gives users a hint to update their implementations.

We are currently using my fork in our project and it's working great so far.