### PR TITLE
Convert to use extensible protocol for serialisation.

### DIFF
--- a/test/taoensso/faraday/tests/main.clj
+++ b/test/taoensso/faraday/tests/main.clj
@@ -359,10 +359,20 @@
    (update-t
     {:update-map {:boolT [:put nil]}}))
 
+  (extend-protocol far/CljVal->DbVal java.util.Date
+    (serialise [x]
+      (far/serialise (pr-str x))))
+
+  (expect
+    (assoc t :date "#inst \"1970-01-01T00:00:00.000-00:00\"")
+    (update-t
+      {:update-map {:date [:put (java.util.Date. (long 0))]}}))
+
   (expect
    (assoc-in t [:map-new :new] "x")
    (update-t
     {:update-map {:map-new [:put {:new "x"}]}})))
+
 
 ;;;; expectation tests
 (let [t {:id 16


### PR DESCRIPTION
We are trying to serialise dates into our dynamodb table and plan to use prismatic schema to deserialise and coerce the data out again. Using protocols allows us to achieve this by implementing a date to string conversion locally without affecting the faraday library. An example of the date serialisation that we wish to use has been included in the test.