### PR TITLE
Fix non-expand mode batch write

### DIFF
--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -1079,10 +1079,9 @@
   (let [expand? *attr-multi-vs?*
         expand? (if (nil? expand?) attr-multi-vs?-default expand?)]
 
-    (if-not expand?
-      (clj-item->db-item attr-multi-vs-map)
-      (let [;; ensure-coll (fn [x] (if (coll?* x) x [x]))
-            ensure-sequential (fn [x] (if (sequential? x) x [x]))]
+    (let [ensure-sequential (fn [x] (if (sequential? x) x [x]))]
+      (if-not expand?
+        (mapv clj-item->db-item (ensure-sequential attr-multi-vs-map))
         (reduce
           (fn [r attr-multi-vs]
             (let [attrs (keys attr-multi-vs)


### PR DESCRIPTION
Treat incoming batch of updates as a seq rather than a single value.

Hi @ptaoussanis, apologies for not submitting 010c151 as a PR, I had forgotten that I had full access to this repo :)

I'm trying to disable the 'expand' behaviour (related to #63). I've found that `attr-multi-vs` appeared to be doing the wrong thing in the 'non-expand' branch - it wasn't treating the incoming batch of updates as a seq and was attempting to convert it directly to a dynamo value. This is working well for me now that I have made this change.