### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ And setup your namespace imports:
 
 #### Option 1 - Run a local DDB instance
 
-First thing is to make sure you've got a DynamoDB Local instance up and running. Follow the [instructions from AWS][] (don't worry, you basically just download a JAR file and run it) or use `brew install dynamodb-local` if you're on OSX and is using Homebrew.
+First thing is to make sure you've got a DynamoDB Local instance up and running. Follow the [instructions from AWS][] (don't worry, you basically just download a JAR file and run it).
 
 Once DynamoDB Local is up and running in your terminal, you should see something like:
 


### PR DESCRIPTION
`dynamodb-local` has been removed from homebrew (see https://github.com/Homebrew/homebrew-core/pull/9175) and as such the readme shouldn't suggest installing it that way.