### PR TITLE
accept keyword index names in scan and query fns

### DIFF
--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -1252,7 +1252,7 @@
     expr-attr-names (.setExpressionAttributeNames expr-attr-names)
     expr-attr-vals  (.setExpressionAttributeValues (clj->db-expr-vals-map expr-attr-vals))
     limit           (.setLimit     (int g))
-    index           (.setIndexName      g)
+    index           (.setIndexName      (name g))
     consistent?     (.setConsistentRead g)
     (coll?* return) (.setAttributesToGet (mapv name return))
     return-cc?      (.setReturnConsumedCapacity (utils/enum :total))
@@ -1316,7 +1316,7 @@
     expr-attr-names (.setExpressionAttributeNames expr-attr-names)
     expr-attr-vals  (.setExpressionAttributeValues (clj->db-expr-vals-map expr-attr-vals))
     filter-expr     (.setFilterExpression filter-expr)
-    index           (.setIndexName index)
+    index           (.setIndexName (name index))
     last-prim-kvs   (.setExclusiveStartKey
                      (clj-item->db-item last-prim-kvs))
     limit           (.setLimit             (int g))

--- a/test/taoensso/faraday/tests/requests.clj
+++ b/test/taoensso/faraday/tests/requests.clj
@@ -416,7 +416,7 @@
                          {:name [:eq "Steve"]
                           :age [:between [10 30]]}
                          {:return :all-projected-attributes
-                          :index "lsindex"
+                          :index :lsindex
                           :order :desc
                           :limit 2})]
   (expect "query" (.getTableName req))
@@ -439,7 +439,7 @@
 (let [req ^ScanRequest (scan-request
                          :scan
                          {:attr-conds      {:age [:in [24 27]]}
-                          :index           "age-index"
+                          :index           :age-index
                           :proj-expr       "age, #t"
                           :expr-attr-names {"#t" "year"}
                           :return          :count


### PR DESCRIPTION
do a `(name index)` in scan-request and query-request fns so that the
index names can be keywords. 