### PR TITLE
Bump aws-java-sdk version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,18 @@
+{:paths ["src"]
+
+ ;; [org.clojure/clojure "1.5.1"]
+ ;;   [com.taoensso/encore "2.88.1"]
+ ;;   [com.taoensso/nippy  "2.12.2"]
+ ;;   [joda-time           "2.9.6"]
+ ;;   [com.amazonaws/aws-java-sdk-dynamodb "1.11.563"
+ ;;    :exclusions [joda-time]]]
+ :deps {org.clojure/clojure {:mvn/version "RELEASE"}
+        com.taoensso/encore {:mvn/version "2.88.1"}
+        com.taoensso/nippy {:mvn/version "2.12.2"}
+        joda-time {:mvn/version "2.9.6"}
+        com.amazonaws/aws-java-sdk-dynamodb {:mvn/version "1.11.563"
+                                             :exclusions [joda-time]}}
+ :mvn/repos
+ {"central" {:url "https://repo1.maven.org/maven2/"}
+  "clojars" {:url "https://clojars.org/repo"}
+  "sonatype-oss-public" {:url "https://oss.sonatype.org/content/groups/public/"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,3 +1,6 @@
+;; This file mirrors vital parts of `project.clj`
+;; It exists only to add possibility to include this project as a git dependency
+
 {:paths ["src"]
 
  ;; [org.clojure/clojure "1.5.1"]

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
    [com.taoensso/encore "2.88.1"]
    [com.taoensso/nippy  "2.12.2"]
    [joda-time           "2.9.6"]
-   [com.amazonaws/aws-java-sdk-dynamodb "1.10.49"
+   [com.amazonaws/aws-java-sdk-dynamodb "1.11.563"
     :exclusions [joda-time]]]
 
   :profiles


### PR DESCRIPTION
There are some breaking changes between `1.10.x` and `1.11.x` versions, most of tools now require `1.11.x`, while faraday crashes with later version.

Just by bumping all the issues seems to be resolved and tests passes. 
`deps.edn` is here only to be able to include this package via `git/url`, which allows us to use this version without waiting for pull request to be accepted.