### PR TITLE
Increase aws-java-sdk-dynamodb version (from 1.10.49 to 1.11.657)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
    [com.taoensso/encore "2.88.1"]
    [com.taoensso/nippy  "2.12.2"]
    [joda-time           "2.9.6"]
-   [com.amazonaws/aws-java-sdk-dynamodb "1.10.49"
+   [com.amazonaws/aws-java-sdk-dynamodb "1.11.657"
     :exclusions [joda-time]]]
 
   :profiles


### PR DESCRIPTION
This closes #113, closes #124 and closes #125.